### PR TITLE
EOEPCA-705: added keyword extraction for CWL items

### DIFF
--- a/core/registrar_pycsw/metadata.py
+++ b/core/registrar_pycsw/metadata.py
@@ -83,6 +83,11 @@ class ISOMetadata:
             'keywords_type': 'theme'
         }
 
+        if 's:keywords' in cwl:
+            mcf['identification']['keywords']['default']['keywords'].extend(
+                cwl['s:keywords'].split(',')
+            )
+
         mcf['dataquality']['scope'] = {'level': 'application'}
 
         if 's:releaseNotes' in cwl:


### PR DESCRIPTION
A small change to add the extraction of keywords (under the `s:keywords` tag) from the CWL file. This will add them to the record in the pycsw table.